### PR TITLE
[Feat] TCP/IP 서버, 클라이언트 소켓 멀티 스레드 작업

### DIFF
--- a/tcpClient/client.py
+++ b/tcpClient/client.py
@@ -1,27 +1,43 @@
-import socket
-import threading
+from socket import *
+from threading import *
 
-client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-client_socket.connect((socket.gethostbyname(socket.gethostname()), 9000))
+def connect(addr):
+    client_socket = socket(AF_INET, SOCK_STREAM)
+    try:
+        client_socket.connect((addr[0], addr[1]))
+        print(f"{addr[0]}:{addr[1]} : Connected")
+    except TimeoutError as e:
+        print(f"{addr[0]}:{addr[1]} : Connection Failed - Timeout Error")
+    finally:
+        return client_socket
 
-def recv_data(client_socket):
+def recv(client_socket, addr):
     try:
         while True:
-            data = client_socket.recv(1024)
-            print("수신받음 : ", repr(data.decode()))
+            data = client_socket.recv(65535)
+            if data.decode() == "SYN-ACK":
+                client_socket.sendall(b"SYN-ACK")
+            print(f"{addr[0]}:{addr[1]} : {data.decode()}")
     except ConnectionAbortedError as e:
-        print("서버와 연결 종료")
-        return
+        print(f"{addr[0]}:{addr[1]} : Disconnected from server")
     return
 
-client_thread = threading.Thread(target=recv_data, args=(client_socket,))
-client_thread.start()
-print("서버 연결 성공")
+def send(client_socket, addr, data):
+    try:
+        client_socket.sendall(data.decode())
+        print(f"{addr[0]}:{addr[1]} : Send successful")
+    except Exception as e:
+        print(f"{addr[0]}:{addr[1]} : Send Failed - {e}")
+    return
 
-while True:
-    msg = input()
-    if msg == "quit":
-        break
-    client_socket.send(msg.encode())
-
-client_socket.close()
+if __name__ == "__main__":
+    addr = ("127.0.0.1", 9000)
+    client_socket = connect(addr)
+    client = Thread(target=recv, args=(client_socket, addr))
+    client.start()
+    while True:
+        data = input("Input : ")
+        if data == "quit":
+            client_socket.close(); break
+        client_socket.send(data.encode())
+    

--- a/tcpServer/server.py
+++ b/tcpServer/server.py
@@ -1,36 +1,67 @@
-import socket
-import threading
+from socket import *
+from threading import *
 
-client_sockets = []
+clients = []
+
+def make_listening_socket(IP, HOST) -> socket:
+    server_socket = socket(AF_INET, SOCK_STREAM) # TCP/IP Protocol
+    server_socket.bind((IP, HOST))
+    server_socket.settimeout(2000)
+    return server_socket
+
+def handshaking(server_socket, client_socket, addr) -> bool:
+    print(f"{server_socket.getsockname()[0]}:{server_socket.getsockname()[1]} : Accept SYN from client({addr[0]}:{addr[1]})")
+    client_socket.sendall(b"SYN-ACK")
+    print(f"{server_socket.getsockname()[0]}:{server_socket.getsockname()[1]} : Send SYN-ACK to client({addr[0]}:{addr[1]})")
+    data = client_socket.recv(1024)
+    print(f"{addr[0]}:{addr[1]} : Received SYN-ACK data({data.decode()})")
+    if (data.decode() == "SYN-ACK"): 
+        return True
+    return False
 
 def client_thread(client_socket, addr):
+    global clients
     try:
         while True:
             data = client_socket.recv(65535)
             if not data: break
-            print("메세지를 전송받았습니다 : ", addr)
-            print("메세지 내용 : ", data.decode())
-            client_socket.send(data)
-        client_socket.close()
+            print(f"{addr[0]}:{addr[1]} : {data.decode()}")
+            for client in clients:
+                client.sendall(data)
     except ConnectionResetError as e:
-        print("Disconnected by User : ", addr)
-    client_sockets.remove(client_socket)
+        print(f"{addr[0]}:{addr[1]} : Disconnected by User")
+    if client_socket in clients:
+        clients.remove(client_socket)
     client_socket.close()
+            
+def start_server(server_socket : socket, max_connection : int) -> int:
+    global clients
+    server_socket.listen()
+    print(f"{server_socket.getsockname()[0]}:{server_socket.getsockname()[1]} : Server Started ...")
+    while not stop_server_flag: # Input flag here
+        client_socket, addr = server_socket.accept()
+        if (len(clients) >= max_connection):
+            print(f"{addr[0]}:{addr[1]} : Accept Denied - Max Connection Error")
+            client_socket.close(); continue
+        if (handshaking(server_socket, client_socket, addr) is False):
+            print(f"{addr[0]}:{addr[1]} : Accept Denied - 3-way-handshaking Error")
+            client_socket.close(); continue
+        client = Thread(target=client_thread, args=(client_socket, addr))
+        clients.append(client_socket)
+        print(f"{addr[0]}:{addr[1]} : Connected Successfully")
+        print(f"{server_socket.getsockname()[0]}:{server_socket.getsockname()[1]} : {len(clients)} connected to server")
+        client.start()
+    server_socket.close()
 
 if __name__ == "__main__":
-    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server_socket.bind((socket.gethostbyname(socket.gethostname()), 9000))
-    server_socket.listen(1)
-    print("서버가 시작되었습니다 : ", server_socket.getsockname())
+    server_socket = make_listening_socket("127.0.0.1", 9000)
+    stop_server_flag = False
+    server = Thread(target=start_server, args=(server_socket, 5))
+    server.start()
     while True:
-        client_socket, addr = server_socket.accept()
-        if (len(client_sockets) >= 2):
-            print("서버에 연결 가능한 Connection 수를 초과하였습니다")
-            client_socket.close()
-        else:
-            thread = threading.Thread(target=client_thread, args=(client_socket, addr))
-            print("연결됨 : ", addr)
-            client_sockets.append(client_socket)
-            print("현재 연결된 사용자 수 : ", len(client_sockets))
-            thread.start()
-    server_socket.close()
+        s = input("Input : ")
+        if s == "end":
+            stop_server_flag = True
+            server.join()
+            break
+    


### PR DESCRIPTION
## PR Type

<!-- 풀 리쿼스트의 타입을 선택하세요. -->

- [x] 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항 <!-- 오타 수정, 탭 사이즈 변경, 변수명 변경 -->
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더 이름 수정
- [ ] 파일 또는 폴더 삭제

## 변경 내용

<!-- 변경 사항을 설명해주세요. -->

- 전달받은 IP, Port 값을 통해 서버와 클라이언트 사이의 소켓 통신을 구축한다.
- 메인 스레드와 TCP/IP 소켓 통신 스레드를 분리한다.
- TCP/IP 서버 소켓의 경우 Listening 스레드와 Client 스레드를 분리한다.
- TCP/IP 클라이언트 소켓의 경우 Recv 스레드를 분리한다.
- 3-way-handshaking 과정 중 SYN-ACK 신호를 통해 서버와 클라이언트 사이의 연결 과정을 print 문을 사용해 콘솔 창으로 시각화한다.

## 관련 이슈

<!-- PR과 연관이 있는 Issue를 연결하세요. -->

- 관련 이슈: #20

## PR Checklist

<!-- 풀 리쿼스트가 다음의 사항을 따르는지 확인하세요. -->

- [x] 커밋 메시지가 가이드라인을 따르는가
- [x] 관련 이슈를 연결하였는가

## 추가 사항

<!-- 스크린샷 등 추가적인 정보를 작성해주세요. -->
